### PR TITLE
SCHED_DEADLINE: Use library for division of 64-bit unsigned ints.

### DIFF
--- a/kernel/sched/core.c
+++ b/kernel/sched/core.c
@@ -8090,7 +8090,7 @@ static u64 actual_dl_runtime(void)
 	if (dl_runtime == RUNTIME_INF)
 		return RUNTIME_INF;
 
-	return (dl_runtime * rt_runtime) / period;
+	return div64_u64 (dl_runtime * rt_runtime, period);
 }
 
 static int check_dl_bw(void)


### PR DESCRIPTION
The ARM architecture does not provide division of 64-bit unsigned
integers, and gcc 4.1.2 complains about missing __aeabi_uldivmod.
